### PR TITLE
Compare account names instead of currency codes

### DIFF
--- a/src/Coinbase.lua
+++ b/src/Coinbase.lua
@@ -70,7 +70,7 @@ end
 
 local function ContainsAccount (accounts, account)
   for index, value in ipairs(accounts) do
-    if value["currency"]["code"] == account["currency"]["code"] then
+    if value["name"] == account["name"] then
       return true
     end
   end
@@ -90,14 +90,14 @@ function RefreshAccount (account, since)
     if not isInArray(value["currency"]["code"], ommittedCurrencies) then
       if value["type"] == "fiat" then
         s[#s+1] = {
-          name = value["currency"]["name"],
+          name = value["currency"]["name"] .. " (" .. value["name"] .. ")",
           market = market,
           currency = currency,
           amount = value["balance"]["amount"]
         }
       else
         s[#s+1] = {
-          name = value["currency"]["name"],
+          name = value["currency"]["name"] .. " (" .. value["name"] .. ")",
           market = market,
           currency = nil,
           quantity = value["balance"]["amount"],


### PR DESCRIPTION
Hello,

as of late the coinbase extension does not fetch my BTC values anymore. 
The `ContainsAccount` method does return true in my case: my primary account has `BTC` as currency code, but there's also an account called `BTC Vault` in my full account list. Thus, Moneymoney does not show the current amount of my primary account.  

I think this what introduced some commits ago. In order to distinguish between accounts with same currency code, I added the account name. 

![grafik](https://user-images.githubusercontent.com/573120/110121062-2dc3d880-7dbe-11eb-83c6-08f4be5124d7.png)

I think this only affects users with an activated "Vault" account. 

Regards,
Johannes
